### PR TITLE
Updated to latest versions of DSE / Ops Center

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,13 @@ RUN curl -o /bin/gosu -SkL "https://github.com/tianon/gosu/releases/download/1.4
 
 
 # DSE tarball can be download into the folder where Dockerfile is
-# wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/dse-5.0.0-bin.tar.gz
-# you may want to replace dse-5.0.0-bin.tar.gz with the corresponding downloaded package name. When
+# wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/dse-5.0.3-bin.tar.gz
+# you may want to replace dse-5.0.3-bin.tar.gz with the corresponding downloaded package name. When
 # downloaded, please remove the version number part of the filename (or create a symlink), so the
 # resulting file is named dse-bin.tar.gz (that way the docker file itself remains version independent).
 #
 # DataStax Agent debian package can be downloaded from
-# wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/datastax-agent_6.0.0_all.deb
+# wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/datastax-agent_6.0.3_all.deb
 # you may want to replace the specific version with the corresponding downloaded package name. When
 # downloaded, please remove the version number part of the filename (or create a symlink), so the
 # resulting file is named datastax-agent_all.deb (that way the docker file itself remains version

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,26 @@ RUN curl -o /bin/gosu -SkL "https://github.com/tianon/gosu/releases/download/1.4
 
 
 # DSE tarball can be download into the folder where Dockerfile is
+# Run this command prior to building the container. Eg. the file should exist already. 
 # wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/dse-5.0.3-bin.tar.gz
 # you may want to replace dse-5.0.3-bin.tar.gz with the corresponding downloaded package name. When
 # downloaded, please remove the version number part of the filename (or create a symlink), so the
 # resulting file is named dse-bin.tar.gz (that way the docker file itself remains version independent).
 #
+# Run this command prior to building the container. Eg. the file should exist already.
+# ln -s dse-5.0.3-bin.tar.gz dse-bin.tar.gz
+#
 # DataStax Agent debian package can be downloaded from
-# wget --user=$USER --password=$PASS http://downloads.datastax.com/enterprise/datastax-agent_6.0.3_all.deb
+# Run this command prior to building the container. Eg. the file should exist already.
+# wget --user=$USER --password=$PASS http://debian.datastax.com/enterprise/pool/datastax-agent_6.0.3_all.deb
 # you may want to replace the specific version with the corresponding downloaded package name. When
 # downloaded, please remove the version number part of the filename (or create a symlink), so the
 # resulting file is named datastax-agent_all.deb (that way the docker file itself remains version
 # independent).
+#
+# Run this command prior to building the container. Eg. the file should exist already.
+#ln -s datastax-agent_6.0.3_all.deb datastax-agent_all.deb
+#
 ADD dse-bin.tar.gz /opt
 ADD datastax-agent_all.deb /tmp
 
@@ -102,3 +111,4 @@ EXPOSE 8012 50030 50060 9290
 EXPOSE 10000
 
 # Graph
+

--- a/OpscDockerfile
+++ b/OpscDockerfile
@@ -20,12 +20,16 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 
 # DSE tarball can be download into the folder where Dockerfile is
+# Run this command prior to building the container. Eg. the file should exist already.
 # wget --user=$USER --password=$PASSWORD http://downloads.datastax.com/enterprise/opscenter-6.0.3.tar.gz
-
+#
 # you may want to replace opscenter-6.0.3.tar.gz with the corresponding downloaded package name. When
 # downloaded, please remove the version number part of the filename (or create a symlink), so the
 # resulting file is named opscenter.tar.gz (that way the docker file itself remains version independent).
-
+#
+# Run this command prior to building the container. Eg. the file should exist already.
+# ln -s opscenter-6.0.3.tar.gz opscenter.tar.gz 
+#
 ADD opscenter.tar.gz /opt
 
 RUN ln -s /opt/ops* /opt/opscenter

--- a/OpscDockerfile
+++ b/OpscDockerfile
@@ -19,6 +19,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     ntp bash tree && \
     rm -rf /var/lib/apt/lists/*
 
+# DSE tarball can be download into the folder where Dockerfile is
+# wget --user=$USER --password=$PASSWORD http://downloads.datastax.com/enterprise/opscenter-6.0.3.tar.gz
+
+# you may want to replace opscenter-6.0.3.tar.gz with the corresponding downloaded package name. When
+# downloaded, please remove the version number part of the filename (or create a symlink), so the
+# resulting file is named opscenter.tar.gz (that way the docker file itself remains version independent).
+
 ADD opscenter.tar.gz /opt
 
 RUN ln -s /opt/ops* /opt/opscenter

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 To build images run the script ./scripts/build_images.sh. This will create two images named opscenter and dse.
 
+
 If you don’t already have the downloads for Ops Centre and DSE, you can obtain them from;
 http://downloads.datastax.com/enterprise. You will require a free, DataStax Academy user account to access the downloads URL.
+
 
 You can sign up for a DataStax Academy account at;
 https://academy.datastax.com
@@ -9,8 +11,9 @@ https://academy.datastax.com
 
 If you would like to retrieve the downloads as part of the Docker build;
 Edit the files;
-Dockerfile
-OpsDockerfile
+* Dockerfile
+* OpsDockerfile
+
 
 then, uncomment the ‘wget’ commands and replace $USER and $PASSWORD with your DataStax Academy username and password.
 
@@ -20,9 +23,11 @@ To start a cluster run the script ./scripts/start_docker_cluster.sh like this:
 You can add more commandline optons to control the DSE nodes (for example pass
 in a -s to enable search).
 
+
 To remove the cluster completely (the images will remain), please run:
   ./scripts/teardown_docker_cluster.sh 3
 Use the same node count as for the start (argument 3 above).
+
 
 For more information please refer to the docker whitepaper at;
 http://www.datastax.com/resources/whitepapers/best-practices-running-datastax-enterprise-within-docker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 To build images run the script ./scripts/build_images.sh. This will create two images named opscenter and dse.
 
+If you don’t already have the downloads for Ops Centre and DSE, you can obtain them from;
+http://downloads.datastax.com/enterprise. You will require a free, DataStax Academy user account to access the downloads URL.
+
+You can sign up for a DataStax Academy account at;
+https://academy.datastax.com
+
+If you would like to retrieve the downloads as part of the Docker build;
+Edit the files;
+Dockerfile
+OpsDockerfile
+
+then, uncomment the ‘wget’ commands and replace $USER and $PASSWORD with your DataStax Academy username and password.
+
+
 To start a cluster run the script ./scripts/start_docker_cluster.sh like this:
    ./scripts/start_docker_cluster.sh dse/docker opscenter 3
 You can add more commandline optons to control the DSE nodes (for example pass
@@ -9,5 +23,6 @@ To remove the cluster completely (the images will remain), please run:
   ./scripts/teardown_docker_cluster.sh 3
 Use the same node count as for the start (argument 3 above).
 
-For more information please refer to the docker whitepaper at datastax.com.
+For more information please refer to the docker whitepaper at;
+http://www.datastax.com/resources/whitepapers/best-practices-running-datastax-enterprise-within-docker
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ http://downloads.datastax.com/enterprise. You will require a free, DataStax Acad
 You can sign up for a DataStax Academy account at;
 https://academy.datastax.com
 
+
 If you would like to retrieve the downloads as part of the Docker build;
 Edit the files;
 Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,29 +1,21 @@
+Pre-requiste : 
+You must have a copy of DSE, Ops Center and the Ops Center Agent, in the same directory as your Dockerfile.
+In order to download the files, you will need to have a DataStax Academy login.
+You can sign up for a free DataStax Academy account at : https://academy.datastax.com
+The directions for obtaining the files (with a valid login) can be found in the respective Docker files;
+* Dockerfile
+* OpscDockerfile
+
+Build Images :
 To build images run the script ./scripts/build_images.sh. This will create two images named opscenter and dse.
 
-
-If you don’t already have the downloads for Ops Centre and DSE, you can obtain them from;
-http://downloads.datastax.com/enterprise. You will require a free, DataStax Academy user account to access the downloads URL.
-
-
-You can sign up for a DataStax Academy account at;
-https://academy.datastax.com
-
-
-If you would like to retrieve the downloads as part of the Docker build;
-Edit the files;
-* Dockerfile
-* OpsDockerfile
-
-
-then, uncomment the ‘wget’ commands and replace $USER and $PASSWORD with your DataStax Academy username and password.
-
-
+Start a Cluster : 
 To start a cluster run the script ./scripts/start_docker_cluster.sh like this:
    ./scripts/start_docker_cluster.sh dse/docker opscenter 3
 You can add more commandline optons to control the DSE nodes (for example pass
 in a -s to enable search).
 
-
+Remove a Cluster :
 To remove the cluster completely (the images will remain), please run:
   ./scripts/teardown_docker_cluster.sh 3
 Use the same node count as for the start (argument 3 above).


### PR DESCRIPTION
Updated the comments to make it clearer that the DSE / Ops Center Tarballs are required prior to building the Docker images.

The updated comments also now include the latest versions of DSE / Ops Center and the Ops Center Agent.
